### PR TITLE
Refactor ThreeSceneSample

### DIFF
--- a/src/utils/threeScene.ts
+++ b/src/utils/threeScene.ts
@@ -1,0 +1,71 @@
+import * as THREE from 'three';
+
+export interface SceneLifecycleHandlers {
+  onInit?: (scene: THREE.Scene, camera: THREE.PerspectiveCamera, renderer: THREE.WebGLRenderer) => void;
+  onAnimationFrame?: (scene: THREE.Scene, camera: THREE.PerspectiveCamera, renderer: THREE.WebGLRenderer) => void;
+}
+
+export interface ThreeSceneInstance {
+  scene: THREE.Scene;
+  camera: THREE.PerspectiveCamera;
+  renderer: THREE.WebGLRenderer;
+  cleanup: () => void;
+}
+
+export function setupThreeScene(container: HTMLElement, handlers: SceneLifecycleHandlers = {}): ThreeSceneInstance {
+  const scene = new THREE.Scene();
+  const camera = new THREE.PerspectiveCamera(75, container.clientWidth / container.clientHeight, 0.1, 1000);
+  const renderer = new THREE.WebGLRenderer({ antialias: true });
+
+  renderer.setSize(container.clientWidth, container.clientHeight);
+  renderer.setPixelRatio(window.devicePixelRatio);
+  container.appendChild(renderer.domElement);
+
+  handlers.onInit?.(scene, camera, renderer);
+
+  const onResize = () => {
+    camera.aspect = container.clientWidth / container.clientHeight;
+    camera.updateProjectionMatrix();
+    renderer.setSize(container.clientWidth, container.clientHeight);
+  };
+
+  let resizeObserver: ResizeObserver | null = null;
+  if (typeof ResizeObserver !== 'undefined') {
+    resizeObserver = new ResizeObserver(onResize);
+    resizeObserver.observe(container);
+  } else {
+    window.addEventListener('resize', onResize);
+  }
+
+  let animationFrameId: number;
+  const animate = () => {
+    animationFrameId = requestAnimationFrame(animate);
+    handlers.onAnimationFrame?.(scene, camera, renderer);
+    renderer.render(scene, camera);
+  };
+  animate();
+
+  const cleanup = () => {
+    cancelAnimationFrame(animationFrameId);
+    if (resizeObserver) {
+      resizeObserver.disconnect();
+    } else {
+      window.removeEventListener('resize', onResize);
+    }
+
+    renderer.dispose();
+    scene.traverse(object => {
+      if (object instanceof THREE.Mesh) {
+        object.geometry?.dispose();
+        if (Array.isArray(object.material)) {
+          object.material.forEach(m => m.dispose());
+        } else {
+          object.material?.dispose();
+        }
+      }
+    });
+    container.innerHTML = '';
+  };
+
+  return { scene, camera, renderer, cleanup };
+}


### PR DESCRIPTION
## Summary
- extract generic setup helper for Three.js scenes
- use helper in `ThreeSceneSample` for easier reuse

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6844a2bc75388325aa93e853a26dbf5d