### PR TITLE
Add persistent header layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,7 +7,21 @@
     <title>Hello math</title>
   </head>
   <body>
-    <div id="app">Loading...</div> 
+    <div id="header">
+      <div id="version-info-banner"></div>
+      <h1 id="page-title">Hello math</h1>
+    </div>
+    <div id="app-layout">
+      <nav id="sidebar">
+        <ul>
+          <li><a href="/" data-navigo>Home</a></li>
+          <li><a href="/counter" data-navigo>Counter</a></li>
+          <li><a href="/three_cube" data-navigo>Cube Scene</a></li>
+          <li><a href="/three_sphere" data-navigo>Sphere Scene</a></li>
+        </ul>
+      </nav>
+      <div id="content">Loading...</div>
+    </div>
     <script type="module" src="/src/main.ts"></script>
   </body>
 </html>

--- a/src/components/versionInfo.ts
+++ b/src/components/versionInfo.ts
@@ -5,8 +5,9 @@
  * Информация извлекается из переменных окружения Vite (VITE_COMMIT_HASH, VITE_COMMIT_DATE).
  */
 export function displayVersionBanner(): void {
-  const versionElement = document.createElement('div');
-  versionElement.id = 'version-info-banner'; // Дадим новый ID или можно оставить старый
+  const existing = document.getElementById('version-info-banner');
+  const versionElement = existing ?? document.createElement('div');
+  versionElement.id = 'version-info-banner';
 
   // Применяем стили программно
   Object.assign(versionElement.style, {
@@ -43,13 +44,13 @@ export function displayVersionBanner(): void {
     }
   }
 
-  // Добавляем элемент в начало body
-  if (document.body) {
-    document.body.prepend(versionElement);
-  } else {
-    // Если body еще не доступно, дождемся загрузки DOM
-    document.addEventListener('DOMContentLoaded', () => {
+  if (!existing) {
+    if (document.body) {
       document.body.prepend(versionElement);
-    });
+    } else {
+      document.addEventListener('DOMContentLoaded', () => {
+        document.body.prepend(versionElement);
+      });
+    }
   }
 }

--- a/src/pages/CounterPage.ts
+++ b/src/pages/CounterPage.ts
@@ -11,8 +11,6 @@ export function renderCounterPage(appElement: HTMLElement): void {
     </div>
     <button id="increment-btn">Increment</button>
     <button id="decrement-btn" style="margin-left: 5px;">Decrement</button>
-    <br><br>
-    <a href="/" data-navigo>Go to Home</a>
   `;
 
   let count = 0;

--- a/src/pages/HomePage.ts
+++ b/src/pages/HomePage.ts
@@ -4,13 +4,9 @@
  */
 export function renderHomePage(appElement: HTMLElement): void {
   appElement.innerHTML = `
-    <h1>Hello math</h1>
     <p>
       This is a simple example of using math in a web application. The math
       library is loaded dynamically.
     </p>
-   <div> <a href="/counter" data-navigo>Go to Counter Page</a></div> 
-   <div>  <a href="/three_cube" data-navigo>Cube Scene</a></div> 
-   <div>  <a href="/three_sphere" data-navigo>Sphere Scene</a></div> 
   `;
 }

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -5,10 +5,10 @@ import { renderCubeScene, renderSphereScene } from '../pages/ThreeScenes';
 const router = new Navigo('/'); // '/' это корневой URL
 
 export function setupRouter(): void {
-  const appElement = document.getElementById('app');
+  const appElement = document.getElementById('content');
 
   if (!appElement) {
-    console.error('App element (#app) not found in the DOM.');
+    console.error('App element (#content) not found in the DOM.');
     return;
   }
 

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -214,3 +214,27 @@ button:focus-visible {
 .read-the-docs {
   color: var(--muted-text-color);
 }
+
+/* Layout for persistent header and sidebar */
+#header {
+  display: flex;
+  align-items: center;
+  padding: 0.5rem 1rem;
+}
+#version-info-banner {
+  margin-right: 1rem;
+}
+#app-layout {
+  display: flex;
+  height: calc(100vh - 50px);
+}
+#sidebar {
+  width: 200px;
+  padding: 1rem;
+  box-sizing: border-box;
+}
+#content {
+  flex-grow: 1;
+  padding: 1rem;
+  overflow: auto;
+}


### PR DESCRIPTION
## Summary
- create a header with version info and title
- add left sidebar navigation and main content area
- adjust router and pages to render into new content container
- reuse existing version banner element
- provide minimal layout styles

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6844a6bded288325abc69d525e7fc570