### PR TITLE
Fix Three.js canvas initial size

### DIFF
--- a/src/utils/threeApp.ts
+++ b/src/utils/threeApp.ts
@@ -9,10 +9,6 @@ export interface SceneManager {
 
 export function createThreeApp(appElement: HTMLElement, setupCallback: (manager: SceneManager) => void): void {
   appElement.innerHTML = `
-    <style>
-      #three-container { width: 100%; height: 100%; display: block; }
-      #three-container canvas { display: block; width: 100%; height: 100%; }
-    </style>
     <div id="three-container"></div>
   `;
 
@@ -22,6 +18,16 @@ export function createThreeApp(appElement: HTMLElement, setupCallback: (manager:
     appElement.innerHTML = '<p>Ошибка: Не удалось инициализировать 3D-представление. Контейнер отсутствует.</p>';
     return;
   }
+
+  // Ensure the container is visible before initializing Three.js
+  container.style.width = '100%';
+  container.style.height = '100%';
+  container.style.display = 'block';
+
+  // Also make sure any canvas added by Three.js fills the container
+  const style = document.createElement('style');
+  style.textContent = `#three-container canvas { display: block; width: 100%; height: 100%; }`;
+  appElement.appendChild(style);
 
   const objects: THREE.Object3D[] = [];
   let updateFn: (() => void) | null = null;

--- a/src/utils/threeScene.ts
+++ b/src/utils/threeScene.ts
@@ -14,19 +14,27 @@ export interface ThreeSceneInstance {
 
 export function setupThreeScene(container: HTMLElement, handlers: SceneLifecycleHandlers = {}): ThreeSceneInstance {
   const scene = new THREE.Scene();
-  const camera = new THREE.PerspectiveCamera(75, container.clientWidth / container.clientHeight, 0.1, 1000);
+  const getDimensions = () => {
+    const rect = container.getBoundingClientRect();
+    const width = rect.width || container.clientWidth || container.parentElement?.clientWidth || window.innerWidth;
+    const height = rect.height || container.clientHeight || container.parentElement?.clientHeight || window.innerHeight;
+    return { width, height };
+  };
+  const { width: initWidth, height: initHeight } = getDimensions();
+  const camera = new THREE.PerspectiveCamera(75, initWidth / initHeight, 0.1, 1000);
   const renderer = new THREE.WebGLRenderer({ antialias: true });
 
-  renderer.setSize(container.clientWidth, container.clientHeight);
+  renderer.setSize(initWidth, initHeight);
   renderer.setPixelRatio(window.devicePixelRatio);
   container.appendChild(renderer.domElement);
 
   handlers.onInit?.(scene, camera, renderer);
 
   const onResize = () => {
-    camera.aspect = container.clientWidth / container.clientHeight;
+    const { width, height } = getDimensions();
+    camera.aspect = width / height;
     camera.updateProjectionMatrix();
-    renderer.setSize(container.clientWidth, container.clientHeight);
+    renderer.setSize(width, height);
   };
 
   let resizeObserver: ResizeObserver | null = null;


### PR DESCRIPTION
## Summary
- keep three container inside content but set style directly
- compute initial canvas dimensions after DOM layout in `setupThreeScene`

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6844aaf0527c8325be6b1ceb4dd30a7a