### PR TITLE
Add fullscreen toggle for Three.js scenes

### DIFF
--- a/src/pages/FunctionPlotPage.ts
+++ b/src/pages/FunctionPlotPage.ts
@@ -1,5 +1,6 @@
 import * as THREE from 'three';
 import { setupThreeScene } from '../utils/threeScene';
+import { addFullscreenToggle } from '../utils/fullscreenToggle';
 import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';
 import { CSS2DRenderer, CSS2DObject } from 'three/examples/jsm/renderers/CSS2DRenderer.js';
 
@@ -14,6 +15,10 @@ export function renderFunctionPlotScene(appElement: HTMLElement): void {
   `;
 
   const container = appElement.querySelector<HTMLDivElement>('#three-container')!;
+  container.style.maxWidth = '100%';
+  container.style.maxHeight = '100%';
+  container.style.overflow = 'hidden';
+  addFullscreenToggle(container);
   const tooltip = appElement.querySelector<HTMLDivElement>('#tooltip')!;
 
   const raycaster = new THREE.Raycaster();

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -244,3 +244,4 @@ button:focus-visible {
   overflow: auto;
   height: 100%;
 }
+.fullscreen-toggle{padding:4px 8px;font-size:14px;}

--- a/src/utils/fullscreenToggle.ts
+++ b/src/utils/fullscreenToggle.ts
@@ -1,0 +1,39 @@
+export function addFullscreenToggle(container: HTMLElement): void {
+  const button = document.createElement('button');
+  button.className = 'fullscreen-toggle';
+  button.textContent = '⛶';
+  button.style.position = 'absolute';
+  button.style.top = '8px';
+  button.style.right = '8px';
+  button.style.zIndex = '10';
+
+  let isFullscreen = false;
+
+  async function toggle() {
+    if (!isFullscreen) {
+      if (container.requestFullscreen) {
+        await container.requestFullscreen();
+      } else if ((container as any).webkitRequestFullscreen) {
+        (container as any).webkitRequestFullscreen();
+      }
+      isFullscreen = true;
+      button.textContent = '✖';
+    } else {
+      if (document.fullscreenElement) {
+        await document.exitFullscreen();
+      }
+      isFullscreen = false;
+      button.textContent = '⛶';
+    }
+  }
+
+  button.addEventListener('click', toggle);
+
+  container.addEventListener('fullscreenchange', () => {
+    isFullscreen = document.fullscreenElement === container;
+    button.textContent = isFullscreen ? '✖' : '⛶';
+  });
+
+  container.style.position = 'relative';
+  container.appendChild(button);
+}

--- a/src/utils/threeApp.ts
+++ b/src/utils/threeApp.ts
@@ -1,6 +1,7 @@
 import * as THREE from 'three';
 import { setupThreeScene } from './threeScene';
 import type { ThreeSceneInstance } from './threeScene';
+import { addFullscreenToggle } from './fullscreenToggle';
 
 export interface SceneManager {
   addObject(object: THREE.Object3D): void;
@@ -22,12 +23,17 @@ export function createThreeApp(appElement: HTMLElement, setupCallback: (manager:
   // Ensure the container is visible before initializing Three.js
   container.style.width = '100%';
   container.style.height = '100%';
+  container.style.maxWidth = '100%';
+  container.style.maxHeight = '100%';
+  container.style.overflow = 'hidden';
   container.style.display = 'block';
 
   // Also make sure any canvas added by Three.js fills the container
   const style = document.createElement('style');
   style.textContent = `#three-container canvas { display: block; width: 100%; height: 100%; }`;
   appElement.appendChild(style);
+
+  addFullscreenToggle(container);
 
   const objects: THREE.Object3D[] = [];
   let updateFn: (() => void) | null = null;


### PR DESCRIPTION
## Summary
- add generic fullscreen toggle helper
- use fullscreen helper in three.js pages
- restrict scene container size and styling

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6845306b4fb08325870293b9067e9103