### PR TITLE
Adjust header title size

### DIFF
--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -221,6 +221,8 @@ button:focus-visible {
 }
 #page-title {
   margin: 0;
+  font-size: 1.5rem;
+  line-height: 1.2;
 }
 #version-info-banner {
   margin-right: 1rem;


### PR DESCRIPTION
## Summary
- reduce default header title font size to 1.5rem to save space

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684531edd51c8325957cbf46cbf76705