### PR TITLE
Add page for plotting formulas with CortexJS

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,6 +19,7 @@
           <li><a href="/three_cube" data-navigo>Cube Scene</a></li>
           <li><a href="/three_sphere" data-navigo>Sphere Scene</a></li>
           <li><a href="/function_plot" data-navigo>3D Function Plot</a></li>
+          <li><a href="/formula_graph" data-navigo>Formula Graph</a></li>
           <li><a href="/riemann" data-navigo>Riemann Zeros</a></li>
         </ul>
       </nav>

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,8 +8,10 @@
       "name": "mathnodejspages",
       "version": "0.0.0",
       "dependencies": {
+        "@cortex-js/compute-engine": "^0.29.1",
         "d3": "^7.9.0",
         "mathjs": "^14.5.2",
+        "mathlive": "^0.105.3",
         "three": "^0.177.0"
       },
       "devDependencies": {
@@ -28,6 +30,20 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@cortex-js/compute-engine": {
+      "version": "0.29.1",
+      "resolved": "https://registry.npmjs.org/@cortex-js/compute-engine/-/compute-engine-0.29.1.tgz",
+      "integrity": "sha512-bCpaGW+Th+6lrTEDom3mNInfu3hu2N79FpUuqdVyvhE1Np4O447O/1gsgqLAFqVjg58cGN0FCAxf8gXkQNF4CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "complex-esm": "^2.1.1-esm1",
+        "decimal.js": "^10.4.3"
+      },
+      "engines": {
+        "node": ">=21.7.3",
+        "npm": ">=10.5.0"
       }
     },
     "node_modules/@dimforge/rapier3d-compat": {
@@ -1104,6 +1120,16 @@
         "node": ">= 10"
       }
     },
+    "node_modules/complex-esm": {
+      "version": "2.1.1-esm1",
+      "resolved": "https://registry.npmjs.org/complex-esm/-/complex-esm-2.1.1-esm1.tgz",
+      "integrity": "sha512-IShBEWHILB9s7MnfyevqNGxV0A1cfcSnewL/4uPFiSxkcQL4Mm3FxJ0pXMtCXuWLjYz3lRRyk6OfkeDZcjD6nw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.14.2",
+        "npm": ">=8.5.0"
+      }
+    },
     "node_modules/complex.js": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/complex.js/-/complex.js-2.4.2.tgz",
@@ -1678,6 +1704,33 @@
       },
       "engines": {
         "node": ">= 18"
+      }
+    },
+    "node_modules/mathlive": {
+      "version": "0.105.3",
+      "resolved": "https://registry.npmjs.org/mathlive/-/mathlive-0.105.3.tgz",
+      "integrity": "sha512-eEnJIlRm1ga18ymY79di5Iuc161CzHs3PTXIg8WUHeEt/jpxFHs2CPVYRNxAzOo+5t4S7lA+HDretW4i5dsTmg==",
+      "license": "MIT",
+      "dependencies": {
+        "@cortex-js/compute-engine": "0.28.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paypal.me/arnogourdol"
+      }
+    },
+    "node_modules/mathlive/node_modules/@cortex-js/compute-engine": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@cortex-js/compute-engine/-/compute-engine-0.28.0.tgz",
+      "integrity": "sha512-kGs74P4KVNLSqu+iVhLSAvodScZdVGoZI2kOsUjnBEFCFjlPJ1Nj5TpBz/4nwPT+viguB+g7VseXsmcxWRx23Q==",
+      "license": "MIT",
+      "dependencies": {
+        "complex-esm": "^2.1.1-esm1",
+        "decimal.js": "^10.4.3"
+      },
+      "engines": {
+        "node": ">=21.7.3",
+        "npm": ">=10.5.0"
       }
     },
     "node_modules/meshoptimizer": {

--- a/package.json
+++ b/package.json
@@ -10,15 +10,17 @@
   },
   "devDependencies": {
     "@types/d3": "^7.4.3",
-    "@types/three": "^0.177.0",
     "@types/mathjs": "^9.4.2",
+    "@types/three": "^0.177.0",
     "navigo": "^8.11.1",
     "typescript": "~5.8.3",
     "vite": "^6.3.5"
   },
   "dependencies": {
+    "@cortex-js/compute-engine": "^0.29.1",
     "d3": "^7.9.0",
     "mathjs": "^14.5.2",
+    "mathlive": "^0.105.3",
     "three": "^0.177.0"
   }
 }

--- a/src/pages/FormulaGraphPage.ts
+++ b/src/pages/FormulaGraphPage.ts
@@ -1,0 +1,93 @@
+import * as d3 from 'd3';
+import { ComputeEngine } from '@cortex-js/compute-engine';
+import 'mathlive';
+
+/**
+ * Page that lets the user input a formula and plots it using D3.
+ * The formula is entered with a MathLive <math-field> and parsed
+ * using CortexJS Compute Engine.
+ */
+export function renderFormulaGraphPage(appElement: HTMLElement): void {
+  appElement.innerHTML = `
+    <div style="margin-bottom:8px;">
+      <label>Formula: <math-field id="formula-input">\\sin(x)</math-field></label>
+    </div>
+    <div style="margin-bottom:8px;">
+      <label>Domain start: <input id="domain-start" type="number" value="0" step="any"></label>
+      <label style="margin-left:4px;">Domain end: <input id="domain-end" type="number" value="6.28" step="any"></label>
+      <button id="plot-btn" style="margin-left:4px;">Plot</button>
+    </div>
+    <div id="plot-container" style="width:100%;height:400px;position:relative;"></div>
+  `;
+
+  const ce = new ComputeEngine();
+  const formulaField = appElement.querySelector('math-field#formula-input') as HTMLElement & { value: string };
+  const startInput = appElement.querySelector<HTMLInputElement>('#domain-start')!;
+  const endInput = appElement.querySelector<HTMLInputElement>('#domain-end')!;
+  const plotBtn = appElement.querySelector<HTMLButtonElement>('#plot-btn')!;
+  const container = appElement.querySelector<HTMLDivElement>('#plot-container')!;
+
+  const margin = { top: 20, right: 20, bottom: 40, left: 40 };
+  let width = container.clientWidth - margin.left - margin.right;
+  let height = container.clientHeight - margin.top - margin.bottom;
+
+  const svg = d3
+    .select(container)
+    .append('svg')
+    .attr('width', container.clientWidth)
+    .attr('height', container.clientHeight);
+
+  const plotArea = svg
+    .append('g')
+    .attr('transform', `translate(${margin.left},${margin.top})`);
+
+  const xAxisGroup = plotArea.append('g').attr('class', 'x-axis');
+  const yAxisGroup = plotArea.append('g').attr('class', 'y-axis');
+  const path = plotArea.append('path').attr('fill', 'none').attr('stroke', 'steelblue').attr('stroke-width', 2);
+
+  function draw(): void {
+    const domainStart = parseFloat(startInput.value);
+    const domainEnd = parseFloat(endInput.value);
+    const latex = formulaField.value || '';
+    const expr = ce.parse(latex);
+    const f = expr.compile();
+
+    const xValues = d3.range(domainStart, domainEnd, (domainEnd - domainStart) / 200);
+    const data = xValues.map(x => ({ x, y: Number(f({ x })) }));
+    const yExtent = d3.extent(data, d => d.y) as [number, number];
+
+    const xScale = d3.scaleLinear().domain([domainStart, domainEnd]).range([0, width]);
+    const yScale = d3.scaleLinear().domain(yExtent).nice().range([height, 0]);
+
+    xAxisGroup
+      .attr('transform', `translate(0,${height})`)
+      .call(d3.axisBottom(xScale));
+
+    yAxisGroup.call(d3.axisLeft(yScale));
+
+    const line = d3
+      .line<{ x: number; y: number }>()
+      .x(d => xScale(d.x))
+      .y(d => yScale(d.y));
+
+    path.datum(data).attr('d', line);
+  }
+
+  plotBtn.addEventListener('click', draw);
+  draw();
+
+  const resizeObserver = new ResizeObserver(() => {
+    const rect = container.getBoundingClientRect();
+    svg.attr('width', rect.width).attr('height', rect.height);
+    width = rect.width - margin.left - margin.right;
+    height = rect.height - margin.top - margin.bottom;
+    draw();
+  });
+  resizeObserver.observe(container);
+
+  (appElement as HTMLElement & { cleanupThreeScene?: () => void }).cleanupThreeScene = () => {
+    plotBtn.removeEventListener('click', draw);
+    resizeObserver.disconnect();
+    svg.remove();
+  };
+}

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -4,6 +4,7 @@ import { renderCounterPage } from '../pages/CounterPage';
 import { renderCubeScene, renderSphereScene } from '../pages/ThreeScenes';
 import { renderFunctionPlotScene } from '../pages/FunctionPlotPage';
 import { renderRiemannHypothesisScene } from '../pages/RiemannHypothesisPage';
+import { renderFormulaGraphPage } from '../pages/FormulaGraphPage';
 const router = new Navigo('/'); // '/' это корневой URL
 
 export function setupRouter(): void {
@@ -42,6 +43,9 @@ export function setupRouter(): void {
     })
     .on('/function_plot', () => {
       renderFunctionPlotScene(appElement);
+    })
+    .on('/formula_graph', () => {
+      renderFormulaGraphPage(appElement);
     })
     .on('/riemann', () => {
       renderRiemannHypothesisScene(appElement);


### PR DESCRIPTION
## Summary
- add `mathlive` and `@cortex-js/compute-engine`
- create new `FormulaGraphPage` with a `math-field` input and D3 graph
- wire page through router and navigation menu

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6845aaeb005c8325a11273b6054bb7dc