### PR TITLE
Add complex number toggle for formula graph

### DIFF
--- a/src/pages/FormulaGraphPage.ts
+++ b/src/pages/FormulaGraphPage.ts
@@ -1,6 +1,8 @@
 import * as d3 from 'd3';
 import { ComputeEngine } from '@cortex-js/compute-engine';
 import 'mathlive';
+import { create, all } from 'mathjs';
+import type { Complex } from 'mathjs';
 
 /**
  * Page that lets the user input a formula and plots it using D3.
@@ -17,14 +19,21 @@ export function renderFormulaGraphPage(appElement: HTMLElement): void {
       <label style="margin-left:4px;">Domain end: <input id="domain-end" type="number" value="6.28" step="any"></label>
       <button id="plot-btn" style="margin-left:4px;">Plot</button>
     </div>
+    <div style="margin-bottom:8px;">
+      <label><input type="checkbox" id="show-real" checked> Real part</label>
+      <label style="margin-left:4px;"><input type="checkbox" id="show-imag"> Imag part</label>
+    </div>
     <div id="plot-container" style="width:100%;height:400px;position:relative;"></div>
   `;
 
   const ce = new ComputeEngine();
+  const math = create(all, {});
   const formulaField = appElement.querySelector('math-field#formula-input') as HTMLElement & { value: string };
   const startInput = appElement.querySelector<HTMLInputElement>('#domain-start')!;
   const endInput = appElement.querySelector<HTMLInputElement>('#domain-end')!;
   const plotBtn = appElement.querySelector<HTMLButtonElement>('#plot-btn')!;
+  const realCheckbox = appElement.querySelector<HTMLInputElement>('#show-real')!;
+  const imagCheckbox = appElement.querySelector<HTMLInputElement>('#show-imag')!;
   const container = appElement.querySelector<HTMLDivElement>('#plot-container')!;
 
   const margin = { top: 20, right: 20, bottom: 40, left: 40 };
@@ -43,21 +52,49 @@ export function renderFormulaGraphPage(appElement: HTMLElement): void {
 
   const xAxisGroup = plotArea.append('g').attr('class', 'x-axis');
   const yAxisGroup = plotArea.append('g').attr('class', 'y-axis');
-  const path = plotArea.append('path').attr('fill', 'none').attr('stroke', 'steelblue').attr('stroke-width', 2);
+  const realPath = plotArea
+    .append('path')
+    .attr('fill', 'none')
+    .attr('stroke', 'steelblue')
+    .attr('stroke-width', 2);
+  const imagPath = plotArea
+    .append('path')
+    .attr('fill', 'none')
+    .attr('stroke', 'tomato')
+    .attr('stroke-width', 2)
+    .attr('stroke-dasharray', '4 2');
 
   function draw(): void {
     const domainStart = parseFloat(startInput.value);
     const domainEnd = parseFloat(endInput.value);
     const latex = formulaField.value || '';
     const expr = ce.parse(latex);
-    const f = expr.compile();
+    const ascii = expr.toString();
+    let compiled;
+    try {
+      compiled = math.compile(ascii);
+    } catch {
+      return;
+    }
 
     const xValues = d3.range(domainStart, domainEnd, (domainEnd - domainStart) / 200);
-    const data = xValues.map(x => ({ x, y: Number(f({ x })) }));
-    const yExtent = d3.extent(data, d => d.y) as [number, number];
+    const data = xValues.map(x => {
+      const v = compiled.evaluate({ x }) as number | Complex;
+      if (typeof v === 'number') return { x, re: v, im: 0 };
+      return { x, re: (v.re as unknown as number) ?? 0, im: (v.im as unknown as number) ?? 0 };
+    });
+
+    let yValues: number[] = [];
+    if (realCheckbox.checked) yValues = yValues.concat(data.map(d => d.re));
+    if (imagCheckbox.checked) yValues = yValues.concat(data.map(d => d.im));
+    let yExtent = d3.extent(yValues) as [number | undefined, number | undefined];
+    if (yExtent[0] === undefined || yExtent[1] === undefined) {
+      yExtent = [0, 1];
+    }
+    const domainY = yExtent as [number, number];
 
     const xScale = d3.scaleLinear().domain([domainStart, domainEnd]).range([0, width]);
-    const yScale = d3.scaleLinear().domain(yExtent).nice().range([height, 0]);
+    const yScale = d3.scaleLinear().domain(domainY).nice().range([height, 0]);
 
     xAxisGroup
       .attr('transform', `translate(0,${height})`)
@@ -70,10 +107,24 @@ export function renderFormulaGraphPage(appElement: HTMLElement): void {
       .x(d => xScale(d.x))
       .y(d => yScale(d.y));
 
-    path.datum(data).attr('d', line);
+    if (realCheckbox.checked) {
+      realPath.style('display', null);
+      realPath.datum(data.map(d => ({ x: d.x, y: d.re }))).attr('d', line);
+    } else {
+      realPath.style('display', 'none');
+    }
+
+    if (imagCheckbox.checked) {
+      imagPath.style('display', null);
+      imagPath.datum(data.map(d => ({ x: d.x, y: d.im }))).attr('d', line);
+    } else {
+      imagPath.style('display', 'none');
+    }
   }
 
   plotBtn.addEventListener('click', draw);
+  realCheckbox.addEventListener('change', draw);
+  imagCheckbox.addEventListener('change', draw);
   draw();
 
   const resizeObserver = new ResizeObserver(() => {
@@ -87,6 +138,8 @@ export function renderFormulaGraphPage(appElement: HTMLElement): void {
 
   (appElement as HTMLElement & { cleanupThreeScene?: () => void }).cleanupThreeScene = () => {
     plotBtn.removeEventListener('click', draw);
+    realCheckbox.removeEventListener('change', draw);
+    imagCheckbox.removeEventListener('change', draw);
     resizeObserver.disconnect();
     svg.remove();
   };


### PR DESCRIPTION
## Summary
- support complex numbers in FormulaGraphPage
- add real/imaginary part checkboxes
- plot real and imaginary parts separately with d3

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68469f8026fc8325be355430287179af