### PR TITLE
Add imaginary range controls to formula graph

### DIFF
--- a/src/pages/FormulaGraphPage.ts
+++ b/src/pages/FormulaGraphPage.ts
@@ -23,6 +23,10 @@ export function renderFormulaGraphPage(appElement: HTMLElement): void {
       <label><input type="checkbox" id="show-real" checked> Real part</label>
       <label style="margin-left:4px;"><input type="checkbox" id="show-imag"> Imag part</label>
     </div>
+    <div id="imag-range" style="display:none;margin-bottom:8px;">
+      <label>Imag start: <input id="imag-start" type="number" value="-1" step="any"></label>
+      <label style="margin-left:4px;">Imag end: <input id="imag-end" type="number" value="1" step="any"></label>
+    </div>
     <div id="plot-container" style="width:100%;height:400px;position:relative;"></div>
   `;
 
@@ -34,6 +38,9 @@ export function renderFormulaGraphPage(appElement: HTMLElement): void {
   const plotBtn = appElement.querySelector<HTMLButtonElement>('#plot-btn')!;
   const realCheckbox = appElement.querySelector<HTMLInputElement>('#show-real')!;
   const imagCheckbox = appElement.querySelector<HTMLInputElement>('#show-imag')!;
+  const imagRangeDiv = appElement.querySelector<HTMLDivElement>('#imag-range')!;
+  const imagStartInput = appElement.querySelector<HTMLInputElement>('#imag-start')!;
+  const imagEndInput = appElement.querySelector<HTMLInputElement>('#imag-end')!;
   const container = appElement.querySelector<HTMLDivElement>('#plot-container')!;
 
   const margin = { top: 20, right: 20, bottom: 40, left: 40 };
@@ -64,6 +71,15 @@ export function renderFormulaGraphPage(appElement: HTMLElement): void {
     .attr('stroke-width', 2)
     .attr('stroke-dasharray', '4 2');
 
+  function toggleImagRange(): void {
+    imagRangeDiv.style.display = imagCheckbox.checked ? 'block' : 'none';
+  }
+
+  function handleImagChange(): void {
+    toggleImagRange();
+    draw();
+  }
+
   function draw(): void {
     const domainStart = parseFloat(startInput.value);
     const domainEnd = parseFloat(endInput.value);
@@ -86,7 +102,14 @@ export function renderFormulaGraphPage(appElement: HTMLElement): void {
 
     let yValues: number[] = [];
     if (realCheckbox.checked) yValues = yValues.concat(data.map(d => d.re));
-    if (imagCheckbox.checked) yValues = yValues.concat(data.map(d => d.im));
+    if (imagCheckbox.checked) {
+      yValues = yValues.concat(data.map(d => d.im));
+      const imStart = parseFloat(imagStartInput.value);
+      const imEnd = parseFloat(imagEndInput.value);
+      if (!Number.isNaN(imStart) && !Number.isNaN(imEnd)) {
+        yValues.push(imStart, imEnd);
+      }
+    }
     let yExtent = d3.extent(yValues) as [number | undefined, number | undefined];
     if (yExtent[0] === undefined || yExtent[1] === undefined) {
       yExtent = [0, 1];
@@ -124,7 +147,8 @@ export function renderFormulaGraphPage(appElement: HTMLElement): void {
 
   plotBtn.addEventListener('click', draw);
   realCheckbox.addEventListener('change', draw);
-  imagCheckbox.addEventListener('change', draw);
+  imagCheckbox.addEventListener('change', handleImagChange);
+  toggleImagRange();
   draw();
 
   const resizeObserver = new ResizeObserver(() => {
@@ -139,7 +163,7 @@ export function renderFormulaGraphPage(appElement: HTMLElement): void {
   (appElement as HTMLElement & { cleanupThreeScene?: () => void }).cleanupThreeScene = () => {
     plotBtn.removeEventListener('click', draw);
     realCheckbox.removeEventListener('change', draw);
-    imagCheckbox.removeEventListener('change', draw);
+    imagCheckbox.removeEventListener('change', handleImagChange);
     resizeObserver.disconnect();
     svg.remove();
   };


### PR DESCRIPTION
## Summary
- add imaginary range input fields to `renderFormulaGraphPage`
- support custom imaginary value range in graph scaling

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6846a1ccb36c8325b98fa3d423576467