### PR TITLE
Refactor FormulaPlot into modular components

### DIFF
--- a/src/pages/FormulaPlot.ts
+++ b/src/pages/FormulaPlot.ts
@@ -1,12 +1,7 @@
-import * as THREE from 'three';
-import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';
-import * as d3 from 'd3';
-import { ComputeEngine } from '@cortex-js/compute-engine';
 import 'mathlive';
-import { create, all } from 'mathjs';
-import type { Complex } from 'mathjs';
-import { setupThreeScene } from '../utils/threeScene';
-import { addFullscreenToggle } from '../utils/fullscreenToggle';
+import { computeFormula } from './formulaPlot/compute';
+import { createThreePlot } from './formulaPlot/threePlot';
+import { createD3Plot } from './formulaPlot/d3Plot';
 
 /**
  * Page that lets the user input a formula and plots it in 3D using Three.js.
@@ -35,8 +30,6 @@ export function renderFormulaPlot(appElement: HTMLElement): void {
     <div id="d3-container" style="width:100%;height:300px;position:relative;margin-top:8px;"></div>
   `;
 
-  const ce = new ComputeEngine();
-  const math = create(all, {});
   const formulaField = appElement.querySelector('math-field#formula-input') as HTMLElement & { value: string };
   const startInput = appElement.querySelector<HTMLInputElement>('#domain-start')!;
   const endInput = appElement.querySelector<HTMLInputElement>('#domain-end')!;
@@ -50,78 +43,8 @@ export function renderFormulaPlot(appElement: HTMLElement): void {
   const threeContainer = appElement.querySelector<HTMLDivElement>('#three-container')!;
   const d3Container = appElement.querySelector<HTMLDivElement>('#d3-container')!;
 
-  threeContainer.style.maxWidth = '100%';
-  threeContainer.style.maxHeight = '100%';
-  threeContainer.style.overflow = 'hidden';
-  d3Container.style.maxWidth = '100%';
-  d3Container.style.maxHeight = '100%';
-  d3Container.style.overflow = 'hidden';
-  addFullscreenToggle(threeContainer);
-  addFullscreenToggle(d3Container);
-
-  let controls: OrbitControls;
-  const sceneInstance = setupThreeScene(threeContainer, {
-    onInit: (scene, camera, renderer) => {
-      // Start the camera at an angle so the imaginary Z axis is visible.
-      // Looking straight down the Z axis hid the imaginary component,
-      // giving the impression that it wasn't being drawn.
-      camera.position.set(5, 5, 10);
-      controls = new OrbitControls(camera, renderer.domElement);
-      controls.enableDamping = true;
-      scene.add(new THREE.AxesHelper(5));
-    },
-    onAnimationFrame: () => {
-      controls.update();
-    },
-  });
-
-  const { scene, cleanup } = sceneInstance;
-  const realMaterial = new THREE.LineBasicMaterial({ color: 0x4682b4 });
-  // Imaginary component is drawn using a solid line to better visualize
-  // functions like sin(x) where the imaginary part is non‑zero. Dashed lines
-  // made the curve appear discontinuous.
-  const imagMaterial = new THREE.LineBasicMaterial({ color: 0xff6347 });
-  let realLine = new THREE.Line(new THREE.BufferGeometry(), realMaterial);
-  let imagLine = new THREE.Line(new THREE.BufferGeometry(), imagMaterial);
-  scene.add(realLine);
-  scene.add(imagLine);
-
-  const margin = { top: 20, right: 20, bottom: 30, left: 40 };
-  let width = d3Container.clientWidth - margin.left - margin.right;
-  let height = d3Container.clientHeight - margin.top - margin.bottom;
-
-  const svg = d3
-    .select(d3Container)
-    .append('svg')
-    .style('display', 'block')
-    .attr('width', d3Container.clientWidth)
-    .attr('height', d3Container.clientHeight);
-
-  const plotArea = svg
-    .append('g')
-    .attr('transform', `translate(${margin.left},${margin.top})`);
-
-  const xScale = d3.scaleLinear().range([0, width]);
-  const yScale = d3.scaleLinear().range([height, 0]);
-
-  const xAxisGroup = plotArea
-    .append('g')
-    .attr('class', 'x-axis')
-    .attr('transform', `translate(0,${height})`);
-
-  const yAxisGroup = plotArea
-    .append('g')
-    .attr('class', 'y-axis');
-
-  const realPath = plotArea
-    .append('path')
-    .attr('stroke', '#4682b4')
-    .attr('fill', 'none');
-
-  const imagPath = plotArea
-    .append('path')
-    .attr('stroke', '#ff6347')
-    .attr('fill', 'none');
+  const threePlot = createThreePlot(threeContainer);
+  const d3Plot = createD3Plot(d3Container);
 
   function toggleRealRange(): void {
     realRangeDiv.style.display = realCheckbox.checked ? 'block' : 'none';
@@ -129,6 +52,32 @@ export function renderFormulaPlot(appElement: HTMLElement): void {
 
   function toggleImagRange(): void {
     imagRangeDiv.style.display = imagCheckbox.checked ? 'block' : 'none';
+  }
+
+  function draw(): void {
+    const domainStart = parseFloat(startInput.value);
+    const domainEnd = parseFloat(endInput.value);
+    let data;
+    try {
+      data = computeFormula(formulaField.value || '', domainStart, domainEnd);
+    } catch {
+      return;
+    }
+
+    const yValues = [
+      ...data.realPoints.map(p => p.y),
+      ...data.imagPoints.map(p => p.y),
+    ];
+    if (imagCheckbox.checked) {
+      const imStart = parseFloat(imagStartInput.value);
+      const imEnd = parseFloat(imagEndInput.value);
+      if (!Number.isNaN(imStart) && !Number.isNaN(imEnd)) {
+        yValues.push(imStart, imEnd);
+      }
+    }
+
+    threePlot.draw(data.realPositions, data.imagPositions, realCheckbox.checked, imagCheckbox.checked);
+    d3Plot.draw(data.realPoints, data.imagPoints, realCheckbox.checked, imagCheckbox.checked);
   }
 
   function handleImagChange(): void {
@@ -141,76 +90,6 @@ export function renderFormulaPlot(appElement: HTMLElement): void {
     draw();
   }
 
-  function draw(): void {
-    const domainStart = parseFloat(startInput.value);
-    const domainEnd = parseFloat(endInput.value);
-    const latex = formulaField.value || '';
-    const expr = ce.parse(latex);
-    const ascii = expr.toString();
-    let compiled;
-    try {
-      compiled = math.compile(ascii);
-    } catch {
-      return;
-    }
-
-    const step = (domainEnd - domainStart) / 200;
-    const xValues = [] as number[];
-    for (let x = domainStart; x <= domainEnd; x += step) xValues.push(x);
-    const realPositions = new Float32Array(xValues.length * 3);
-    const imagPositions = new Float32Array(xValues.length * 3);
-
-    xValues.forEach((x, i) => {
-      const v = compiled.evaluate({ x }) as number | Complex;
-      const re = typeof v === 'number' ? v : (v.re as unknown as number) ?? 0;
-      const im = typeof v === 'number' ? 0 : (v.im as unknown as number) ?? 0;
-      realPositions[i * 3] = x;
-      realPositions[i * 3 + 1] = re;
-      realPositions[i * 3 + 2] = 0;
-      imagPositions[i * 3] = x;
-      imagPositions[i * 3 + 1] = 0;
-      imagPositions[i * 3 + 2] = im;
-    });
-
-    const realPoints = xValues.map((x, i) => ({ x, y: realPositions[i * 3 + 1] }));
-    const imagPoints = xValues.map((x, i) => ({ x, y: imagPositions[i * 3 + 2] }));
-    const yValues = [
-      ...realPoints.map(p => p.y),
-      ...imagPoints.map(p => p.y),
-    ];
-    if (imagCheckbox.checked) {
-      const imStart = parseFloat(imagStartInput.value);
-      const imEnd = parseFloat(imagEndInput.value);
-      if (!Number.isNaN(imStart) && !Number.isNaN(imEnd)) {
-        yValues.push(imStart, imEnd);
-      }
-    }
-    const yExtent = d3.extent(yValues) as [number, number];
-    xScale.domain([domainStart, domainEnd]);
-    yScale.domain(yExtent);
-    xAxisGroup.call(d3.axisBottom(xScale));
-    yAxisGroup.call(d3.axisLeft(yScale));
-    const lineGenerator = d3
-      .line<{ x: number; y: number }>()
-      .x(d => xScale(d.x))
-      .y(d => yScale(d.y));
-    realPath.attr('d', lineGenerator(realPoints));
-    imagPath.attr('d', lineGenerator(imagPoints));
-
-    realLine.geometry.dispose();
-    imagLine.geometry.dispose();
-    realLine.geometry = new THREE.BufferGeometry();
-    realLine.geometry.setAttribute('position', new THREE.BufferAttribute(realPositions, 3));
-    imagLine.geometry = new THREE.BufferGeometry();
-    imagLine.geometry.setAttribute('position', new THREE.BufferAttribute(imagPositions, 3));
-    imagLine.computeLineDistances();
-
-    realLine.visible = realCheckbox.checked;
-    imagLine.visible = imagCheckbox.checked;
-    realPath.style('display', realCheckbox.checked ? 'inline' : 'none');
-    imagPath.style('display', imagCheckbox.checked ? 'inline' : 'none');
-  }
-
   plotBtn.addEventListener('click', draw);
   realCheckbox.addEventListener('change', handleRealChange);
   imagCheckbox.addEventListener('change', handleImagChange);
@@ -218,25 +97,11 @@ export function renderFormulaPlot(appElement: HTMLElement): void {
   toggleImagRange();
   draw();
 
-  const resizeObserver = new ResizeObserver(() => {
-    const rect = d3Container.getBoundingClientRect();
-    svg.attr('width', rect.width).attr('height', rect.height);
-    width = rect.width - margin.left - margin.right;
-    height = rect.height - margin.top - margin.bottom;
-    xScale.range([0, width]);
-    yScale.range([height, 0]);
-    xAxisGroup.attr('transform', `translate(0,${height})`).call(d3.axisBottom(xScale));
-    yAxisGroup.call(d3.axisLeft(yScale));
-    draw();
-  });
-  resizeObserver.observe(d3Container);
-
   (appElement as HTMLElement & { cleanupThreeScene?: () => void }).cleanupThreeScene = () => {
     plotBtn.removeEventListener('click', draw);
     realCheckbox.removeEventListener('change', handleRealChange);
     imagCheckbox.removeEventListener('change', handleImagChange);
-    resizeObserver.disconnect();
-    svg.remove();
-    cleanup();
+    d3Plot.cleanup();
+    threePlot.cleanup();
   };
 }

--- a/src/pages/formulaPlot/compute.ts
+++ b/src/pages/formulaPlot/compute.ts
@@ -1,0 +1,51 @@
+import { ComputeEngine } from '@cortex-js/compute-engine';
+import { create, all } from 'mathjs';
+import type { Complex } from 'mathjs';
+
+const ce = new ComputeEngine();
+const math = create(all, {});
+
+export interface FormulaData {
+  realPositions: Float32Array;
+  imagPositions: Float32Array;
+  realPoints: { x: number; y: number }[];
+  imagPoints: { x: number; y: number }[];
+}
+
+export function computeFormula(
+  latex: string,
+  domainStart: number,
+  domainEnd: number,
+  steps = 200,
+): FormulaData {
+  const expr = ce.parse(latex);
+  const ascii = expr.toString();
+  let compiled;
+  try {
+    compiled = math.compile(ascii);
+  } catch {
+    throw new Error('Invalid formula');
+  }
+  const step = (domainEnd - domainStart) / steps;
+  const xValues: number[] = [];
+  for (let x = domainStart; x <= domainEnd; x += step) xValues.push(x);
+
+  const realPositions = new Float32Array(xValues.length * 3);
+  const imagPositions = new Float32Array(xValues.length * 3);
+  xValues.forEach((x, i) => {
+    const v = compiled.evaluate({ x }) as number | Complex;
+    const re = typeof v === 'number' ? v : (v.re as unknown as number) ?? 0;
+    const im = typeof v === 'number' ? 0 : (v.im as unknown as number) ?? 0;
+    realPositions[i * 3] = x;
+    realPositions[i * 3 + 1] = re;
+    realPositions[i * 3 + 2] = 0;
+    imagPositions[i * 3] = x;
+    imagPositions[i * 3 + 1] = 0;
+    imagPositions[i * 3 + 2] = im;
+  });
+
+  const realPoints = xValues.map((x, i) => ({ x, y: realPositions[i * 3 + 1] }));
+  const imagPoints = xValues.map((x, i) => ({ x, y: imagPositions[i * 3 + 2] }));
+
+  return { realPositions, imagPositions, realPoints, imagPoints };
+}

--- a/src/pages/formulaPlot/d3Plot.ts
+++ b/src/pages/formulaPlot/d3Plot.ts
@@ -1,0 +1,114 @@
+import * as d3 from 'd3';
+import { addFullscreenToggle } from '../../utils/fullscreenToggle';
+
+export interface D3Plot {
+  draw: (
+    real: { x: number; y: number }[],
+    imag: { x: number; y: number }[],
+    showReal: boolean,
+    showImag: boolean,
+  ) => void;
+  cleanup: () => void;
+}
+
+export function createD3Plot(container: HTMLDivElement): D3Plot {
+  container.style.maxWidth = '100%';
+  container.style.maxHeight = '100%';
+  container.style.overflow = 'hidden';
+  addFullscreenToggle(container);
+
+  const margin = { top: 20, right: 20, bottom: 30, left: 40 };
+  let width = container.clientWidth - margin.left - margin.right;
+  let height = container.clientHeight - margin.top - margin.bottom;
+
+  const svg = d3
+    .select(container)
+    .append('svg')
+    .style('display', 'block')
+    .attr('width', container.clientWidth)
+    .attr('height', container.clientHeight);
+
+  const plotArea = svg
+    .append('g')
+    .attr('transform', `translate(${margin.left},${margin.top})`);
+
+  const xScale = d3.scaleLinear().range([0, width]);
+  const yScale = d3.scaleLinear().range([height, 0]);
+
+  const xAxisGroup = plotArea
+    .append('g')
+    .attr('class', 'x-axis')
+    .attr('transform', `translate(0,${height})`);
+
+  const yAxisGroup = plotArea
+    .append('g')
+    .attr('class', 'y-axis');
+
+  const realPath = plotArea
+    .append('path')
+    .attr('stroke', '#4682b4')
+    .attr('fill', 'none');
+
+  const imagPath = plotArea
+    .append('path')
+    .attr('stroke', '#ff6347')
+    .attr('fill', 'none');
+
+  let lastReal: { x: number; y: number }[] = [];
+  let lastImag: { x: number; y: number }[] = [];
+  let lastShowReal = true;
+  let lastShowImag = true;
+
+  function internalDraw(): void {
+    const yValues = [...lastReal.map(p => p.y), ...lastImag.map(p => p.y)];
+    const xValues = [...lastReal.map(p => p.x), ...lastImag.map(p => p.x)];
+    const yExtent = d3.extent(yValues) as [number, number];
+    const xExtent = d3.extent(xValues) as [number, number];
+    xScale.domain(xExtent);
+    yScale.domain(yExtent);
+    xAxisGroup.call(d3.axisBottom(xScale));
+    yAxisGroup.call(d3.axisLeft(yScale));
+    const lineGenerator = d3
+      .line<{ x: number; y: number }>()
+      .x(d => xScale(d.x))
+      .y(d => yScale(d.y));
+    realPath
+      .attr('d', lineGenerator(lastReal))
+      .style('display', lastShowReal ? 'inline' : 'none');
+    imagPath
+      .attr('d', lineGenerator(lastImag))
+      .style('display', lastShowImag ? 'inline' : 'none');
+  }
+
+  function draw(
+    real: { x: number; y: number }[],
+    imag: { x: number; y: number }[],
+    showReal: boolean,
+    showImag: boolean,
+  ): void {
+    lastReal = real;
+    lastImag = imag;
+    lastShowReal = showReal;
+    lastShowImag = showImag;
+    internalDraw();
+  }
+
+  const resizeObserver = new ResizeObserver(() => {
+    const rect = container.getBoundingClientRect();
+    svg.attr('width', rect.width).attr('height', rect.height);
+    width = rect.width - margin.left - margin.right;
+    height = rect.height - margin.top - margin.bottom;
+    xScale.range([0, width]);
+    yScale.range([height, 0]);
+    xAxisGroup.attr('transform', `translate(0,${height})`);
+    internalDraw();
+  });
+  resizeObserver.observe(container);
+
+  function cleanup(): void {
+    resizeObserver.disconnect();
+    svg.remove();
+  }
+
+  return { draw, cleanup };
+}

--- a/src/pages/formulaPlot/threePlot.ts
+++ b/src/pages/formulaPlot/threePlot.ts
@@ -1,0 +1,64 @@
+import * as THREE from 'three';
+import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';
+import { setupThreeScene } from '../../utils/threeScene';
+import { addFullscreenToggle } from '../../utils/fullscreenToggle';
+
+export interface ThreePlot {
+  draw: (
+    realPositions: Float32Array,
+    imagPositions: Float32Array,
+    showReal: boolean,
+    showImag: boolean,
+  ) => void;
+  cleanup: () => void;
+}
+
+export function createThreePlot(container: HTMLDivElement): ThreePlot {
+  container.style.maxWidth = '100%';
+  container.style.maxHeight = '100%';
+  container.style.overflow = 'hidden';
+  addFullscreenToggle(container);
+
+  let controls: OrbitControls;
+  const sceneInstance = setupThreeScene(container, {
+    onInit: (scene, camera, renderer) => {
+      camera.position.set(5, 5, 10);
+      controls = new OrbitControls(camera, renderer.domElement);
+      controls.enableDamping = true;
+      scene.add(new THREE.AxesHelper(5));
+    },
+    onAnimationFrame: () => {
+      controls.update();
+    },
+  });
+
+  const { scene, cleanup } = sceneInstance;
+  const realMaterial = new THREE.LineBasicMaterial({ color: 0x4682b4 });
+  const imagMaterial = new THREE.LineBasicMaterial({ color: 0xff6347 });
+  let realLine = new THREE.Line(new THREE.BufferGeometry(), realMaterial);
+  let imagLine = new THREE.Line(new THREE.BufferGeometry(), imagMaterial);
+  scene.add(realLine);
+  scene.add(imagLine);
+
+  function draw(
+    realPositions: Float32Array,
+    imagPositions: Float32Array,
+    showReal: boolean,
+    showImag: boolean,
+  ): void {
+    realLine.geometry.dispose();
+    imagLine.geometry.dispose();
+    realLine.geometry = new THREE.BufferGeometry();
+    realLine.geometry.setAttribute('position', new THREE.BufferAttribute(realPositions, 3));
+    imagLine.geometry = new THREE.BufferGeometry();
+    imagLine.geometry.setAttribute('position', new THREE.BufferAttribute(imagPositions, 3));
+    imagLine.computeLineDistances();
+    realLine.visible = showReal;
+    imagLine.visible = showImag;
+  }
+
+  return {
+    draw,
+    cleanup,
+  };
+}


### PR DESCRIPTION
## Summary
- split FormulaPlot into smaller files
- add compute, D3, and Three.js helpers
- keep public `renderFormulaPlot` entry point

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6846e8e1429c83259b8fc9869922b16d