### PR TITLE
Add imaginary axis support to formula plot

### DIFF
--- a/src/pages/FormulaPlot.ts
+++ b/src/pages/FormulaPlot.ts
@@ -58,8 +58,24 @@ export function renderFormulaPlot(appElement: HTMLElement): void {
     const domainStart = parseFloat(startInput.value);
     const domainEnd = parseFloat(endInput.value);
     let data;
+    let imagStart: number | undefined;
+    let imagEnd: number | undefined;
+    if (imagCheckbox.checked) {
+      const imStart = parseFloat(imagStartInput.value);
+      const imEnd = parseFloat(imagEndInput.value);
+      if (!Number.isNaN(imStart) && !Number.isNaN(imEnd)) {
+        imagStart = imStart;
+        imagEnd = imEnd;
+      }
+    }
     try {
-      data = computeFormula(formulaField.value || '', domainStart, domainEnd);
+      data = computeFormula(
+        formulaField.value || '',
+        domainStart,
+        domainEnd,
+        imagStart,
+        imagEnd,
+      );
     } catch {
       return;
     }
@@ -68,12 +84,8 @@ export function renderFormulaPlot(appElement: HTMLElement): void {
       ...data.realPoints.map(p => p.y),
       ...data.imagPoints.map(p => p.y),
     ];
-    if (imagCheckbox.checked) {
-      const imStart = parseFloat(imagStartInput.value);
-      const imEnd = parseFloat(imagEndInput.value);
-      if (!Number.isNaN(imStart) && !Number.isNaN(imEnd)) {
-        yValues.push(imStart, imEnd);
-      }
+    if (typeof imagStart === 'number' && typeof imagEnd === 'number') {
+      yValues.push(imagStart, imagEnd);
     }
 
     threePlot.draw(data.realPositions, data.imagPositions, realCheckbox.checked, imagCheckbox.checked);

--- a/src/pages/formulaPlot/compute.ts
+++ b/src/pages/formulaPlot/compute.ts
@@ -10,12 +10,18 @@ export interface FormulaData {
   imagPositions: Float32Array;
   realPoints: { x: number; y: number }[];
   imagPoints: { x: number; y: number }[];
+  imagArgRealPositions?: Float32Array;
+  imagArgImagPositions?: Float32Array;
+  imagArgRealPoints?: { x: number; y: number }[];
+  imagArgImagPoints?: { x: number; y: number }[];
 }
 
 export function computeFormula(
   latex: string,
   domainStart: number,
   domainEnd: number,
+  imagStart?: number,
+  imagEnd?: number,
   steps = 200,
 ): FormulaData {
   const expr = ce.parse(latex);
@@ -47,5 +53,46 @@ export function computeFormula(
   const realPoints = xValues.map((x, i) => ({ x, y: realPositions[i * 3 + 1] }));
   const imagPoints = xValues.map((x, i) => ({ x, y: imagPositions[i * 3 + 2] }));
 
-  return { realPositions, imagPositions, realPoints, imagPoints };
+  let imagArgRealPositions: Float32Array | undefined;
+  let imagArgImagPositions: Float32Array | undefined;
+  let imagArgRealPoints: { x: number; y: number }[] | undefined;
+  let imagArgImagPoints: { x: number; y: number }[] | undefined;
+
+  if (
+    typeof imagStart === 'number' &&
+    typeof imagEnd === 'number' &&
+    !Number.isNaN(imagStart) &&
+    !Number.isNaN(imagEnd)
+  ) {
+    const stepImag = (imagEnd - imagStart) / steps;
+    const yValues: number[] = [];
+    for (let y = imagStart; y <= imagEnd; y += stepImag) yValues.push(y);
+    imagArgRealPositions = new Float32Array(yValues.length * 3);
+    imagArgImagPositions = new Float32Array(yValues.length * 3);
+    yValues.forEach((y, i) => {
+      const arg = math.complex(0, y);
+      const v = compiled.evaluate({ x: arg }) as number | Complex;
+      const re = typeof v === 'number' ? v : (v.re as unknown as number) ?? 0;
+      const im = typeof v === 'number' ? 0 : (v.im as unknown as number) ?? 0;
+      imagArgRealPositions![i * 3] = 0;
+      imagArgRealPositions![i * 3 + 1] = re;
+      imagArgRealPositions![i * 3 + 2] = y;
+      imagArgImagPositions![i * 3] = 0;
+      imagArgImagPositions![i * 3 + 1] = im;
+      imagArgImagPositions![i * 3 + 2] = y;
+    });
+    imagArgRealPoints = yValues.map((y, i) => ({ x: y, y: imagArgRealPositions![i * 3 + 1] }));
+    imagArgImagPoints = yValues.map((y, i) => ({ x: y, y: imagArgImagPositions![i * 3 + 1] }));
+  }
+
+  return {
+    realPositions,
+    imagPositions,
+    realPoints,
+    imagPoints,
+    imagArgRealPositions,
+    imagArgImagPositions,
+    imagArgRealPoints,
+    imagArgImagPoints,
+  };
 }


### PR DESCRIPTION
## Summary
- extend `computeFormula` to accept imaginary range arguments
- calculate values along the imaginary axis when bounds provided
- pass the new parameters from `FormulaPlot` when drawing

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6846ec8ab70883258e3b192bf60409e7